### PR TITLE
[Bugfix] [Custom Logic] OnChatInput

### DIFF
--- a/Assembly/Scripts/GameManagers/ChatManager.cs
+++ b/Assembly/Scripts/GameManagers/ChatManager.cs
@@ -4,6 +4,7 @@ using Weather;
 using UI;
 using Utility;
 using CustomSkins;
+using CustomLogic;
 using ApplicationManagers;
 using System.Diagnostics;
 using Settings;
@@ -124,6 +125,7 @@ namespace GameManagers
         {
             if (input == string.Empty)
                 return;
+            CustomLogicManager.Evaluator.OnChatInput(input);
             if (input.StartsWith("/"))
             {
                 if (input.Length == 1)

--- a/Assembly/Scripts/GameManagers/ChatManager.cs
+++ b/Assembly/Scripts/GameManagers/ChatManager.cs
@@ -125,7 +125,6 @@ namespace GameManagers
         {
             if (input == string.Empty)
                 return;
-            CustomLogicManager.Evaluator.OnChatInput(input);
             if (input.StartsWith("/"))
             {
                 if (input.Length == 1)
@@ -139,6 +138,7 @@ namespace GameManagers
                 string name = PhotonNetwork.player.GetStringProperty(PlayerProperty.Name);
                 SendChatAll(name + ": " + input);
             }
+            CustomLogicManager.Evaluator.OnChatInput(input);
         }
 
         private static void HandleCommand(string[] args)


### PR DESCRIPTION
Closes (Issue not listed at time of pull request)

**Notes for the reviewer:**

*CustomLogicManager.Evaluator.OnChatInput() is never called; this fix adds a call in ChatManager.HandleInput() (for any nonempty local chat input).*
